### PR TITLE
hold last frame

### DIFF
--- a/generate_animation.sh
+++ b/generate_animation.sh
@@ -7,3 +7,6 @@
 # (20 fps instead of 30 fps makes it 6.6x actually)
 ffmpeg -framerate 20 -i plots/vary_N/routes_boston_N%d0.png boston_animation_10x.mp4
 ffmpeg -framerate 20 -i plots/vary_N_zoom/routes_boston_N%d0.png boston_animation_zoom_10x.mp4
+
+#additional option to hold last frame for 2 seconds
+#ffmpeg -framerate 20 -i plots/vary_N/routes_boston_N%d0.png -vf tpad=stop_mode=clone:stop_duration=2  boston_animation_10x.mp4


### PR DESCRIPTION
added an option to hold the last frame for 2 seconds so that the video ends less abruptly